### PR TITLE
Improve local developer experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# Targets
+.PHONY: all build dev clean
+
+all: build
+
+build:
+	@echo "Building library optimizer"
+	cargo build --release
+
+test:
+	@echo "Running tests..."
+	cargo test
+
+dev:
+	@echo "Starting services in development mode..."
+	mkdir ./data/tv
+	mkdir ./data/movies
+	TV_DIR=./data/tv MOVIE_DIR=./data/movies cargo watch -x run
+
+clean:
+	@echo "Cleaning up build artifacts..."
+	cargo clean

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Library Optimizer
+
+## Dependencies
+
+1. [Make](https://www.gnu.org/software/make/manual/make.html)
+2. [Cargo watch](https://crates.io/crates/cargo-watch)
+
+## Running Locally
+
+```bash
+make dev
+```
+
+API is now available at localhost:8080/ and files created under `./data/movies` and `./data/tv` will be tracked.

--- a/src/config/logging.rs
+++ b/src/config/logging.rs
@@ -1,0 +1,12 @@
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+pub fn init() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "library_optimizer=debug,axum=debug,tower_http=debug".into()),
+        )
+        .with(tracing_subscriber::fmt::layer().json())
+        .init();
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,2 @@
+pub mod logging;
+pub mod runtime;

--- a/src/config/runtime.rs
+++ b/src/config/runtime.rs
@@ -1,0 +1,10 @@
+use tokio::runtime::{Builder, Runtime};
+
+pub async fn build(cpus: usize) -> Runtime {
+    Builder::new_multi_thread()
+        .worker_threads(cpus * 2)
+        .max_blocking_threads(cpus * 2)
+        .enable_all()
+        .build()
+        .unwrap()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,43 +1,31 @@
-use axum::{response::Html, routing::get, Router};
+mod config;
+mod server;
+
+use crate::config::logging;
 use notify::{recommended_watcher, RecursiveMode, Watcher};
+use std::env;
 use std::path::Path;
-use std::sync::{mpsc, Arc, Mutex};
-use tokio::net::TcpListener;
-use tokio::runtime::Builder;
-use tower_http::compression::CompressionLayer;
-use tower_http::trace::TraceLayer;
+use std::sync::{mpsc::channel, Arc, Mutex};
 use tracing::{debug, error, info};
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "library_optimizer=debug,axum=debug,tower_http=debug".into()),
-        )
-        .with(tracing_subscriber::fmt::layer().json())
-        .init();
-
+    logging::init();
     let version = option_env!("BUILD_HASH").unwrap_or("dev-build");
 
     info!("Running library optimizer: {}", version);
     let cpus = num_cpus::get();
-    debug!("CPUS: {}", cpus);
+    debug!("Current CPU count: {}", cpus);
 
-    let rt = Builder::new_multi_thread()
-        .worker_threads(cpus * 2) // Fewer worker threads for handling async tasks
-        .max_blocking_threads(cpus * 2) // More blocking threads for handling long-running blocking operations
-        .enable_all()
-        .build()
-        .unwrap();
-    let directories_to_watch = ["./data/tv", "./data/movies"];
+    let rt = config::runtime::build(cpus).await;
 
-    // Create a channel for communication between threads
-    let (sender, receiver) = mpsc::channel();
+    let tv_dir = env::var("TV_DIR").unwrap_or(String::from("/data/tv"));
+    let movies_dir = env::var("MOVIE_DIR").unwrap_or(String::from("/data/media"));
+    let directories_to_watch = [tv_dir, movies_dir];
 
-    // Spawn a Tokio task to receive and print messages from the channel
+    // File notification channel
+    let (sender, receiver) = channel();
+
     let receiver_arc = Arc::new(Mutex::new(receiver));
     let receiver_arc_clone = receiver_arc.clone();
     rt.spawn(async move {
@@ -47,23 +35,19 @@ async fn main() {
         }
     });
 
-    // Spawn a Tokio task for each directory to monitor file changes and send messages to the channel
     let sender_arc = Arc::new(Mutex::new(sender));
     for dir in directories_to_watch {
         let sender_arc_clone = sender_arc.clone();
         let dir_clone = dir.to_string();
 
         rt.spawn(async move {
-            // Create a watcher with a debounce delay
-            let (watcher_sender, watcher_receiver) = mpsc::channel();
+            let (watcher_sender, watcher_receiver) = channel();
             let mut file_watcher = recommended_watcher(watcher_sender).unwrap();
 
-            // Start watching the directory
             file_watcher
                 .watch(Path::new(&dir_clone), RecursiveMode::Recursive)
                 .unwrap();
 
-            // Handle file system events
             loop {
                 match watcher_receiver.recv() {
                     Ok(event) => {
@@ -75,16 +59,5 @@ async fn main() {
         });
     }
 
-    // Set up the Axum server
-    let app = Router::new()
-        .route("/", get(handle_request))
-        .layer(TraceLayer::new_for_http())
-        .layer(CompressionLayer::new());
-    let tcp_listener = TcpListener::bind("0.0.0.0:8080").await.unwrap();
-    info!("Starting server on 8080");
-    axum::serve(tcp_listener, app).await.unwrap();
-}
-
-async fn handle_request() -> Html<&'static str> {
-    Html("<h1>Hello, World!</h1>")
+    server::serve().await;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 mod config;
 mod server;
 
-use crate::config::logging;
 use notify::{recommended_watcher, RecursiveMode, Watcher};
 use std::env;
 use std::path::Path;
@@ -10,7 +9,7 @@ use tracing::{debug, error, info};
 
 #[tokio::main]
 async fn main() {
-    logging::init();
+    config::logging::init();
     let version = option_env!("BUILD_HASH").unwrap_or("dev-build");
 
     info!("Running library optimizer: {}", version);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,7 @@
 pub mod routes;
 
 use crate::server::routes::create_routes;
+
 use axum::Router;
 use tokio::net::TcpListener;
 use tower_http::{compression::CompressionLayer, trace::TraceLayer};

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,0 +1,19 @@
+pub mod routes;
+
+use crate::server::routes::create_routes;
+use axum::Router;
+use tokio::net::TcpListener;
+use tower_http::{compression::CompressionLayer, trace::TraceLayer};
+use tracing::info;
+
+pub async fn serve() {
+    let app = Router::new()
+        .nest("/", create_routes())
+        .layer(TraceLayer::new_for_http())
+        .layer(CompressionLayer::new());
+
+    let tcp_listener = TcpListener::bind("0.0.0.0:8080").await.unwrap();
+
+    info!("Starting server on 8080");
+    axum::serve(tcp_listener, app).await.unwrap();
+}

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -1,0 +1,8 @@
+use crate::server::routes::v1::create_v1_routes;
+use axum::Router;
+
+pub mod v1;
+
+pub fn create_routes() -> Router {
+    Router::new().nest("/v1/", create_v1_routes())
+}

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -1,4 +1,5 @@
 use crate::server::routes::v1::create_v1_routes;
+
 use axum::Router;
 
 pub mod v1;

--- a/src/server/routes/v1/hello_world.rs
+++ b/src/server/routes/v1/hello_world.rs
@@ -1,0 +1,5 @@
+use axum::response::Html;
+
+pub fn hello_world_route() -> Html<&'static str> {
+    Html("<h1>Hello, World!</h1>")
+}

--- a/src/server/routes/v1/mod.rs
+++ b/src/server/routes/v1/mod.rs
@@ -1,5 +1,6 @@
+use crate::server::routes::v1::hello_world::hello_world_route;
+
 use axum::{routing::get, Router};
-use hello_world::hello_world_route;
 
 pub mod hello_world;
 

--- a/src/server/routes/v1/mod.rs
+++ b/src/server/routes/v1/mod.rs
@@ -1,0 +1,8 @@
+use axum::{routing::get, Router};
+use hello_world::hello_world_route;
+
+pub mod hello_world;
+
+pub fn create_v1_routes() -> Router {
+    Router::new().route("/", get(hello_world_route()))
+}


### PR DESCRIPTION
Goal here was to improve the local developer experience and better structure the project.

- logging/runtime config is now in the config/ folder
- all the HTTP server code now lives in the server/ folder
- both of the above result in a cleaner main.rs file (more refactoring coming)
- create a makefile with common commands
- pull in movie and tv folders from env, this allows us to easily run in docker and locally
- add some basic steps to the readme